### PR TITLE
Verify TLS for non-local email servers

### DIFF
--- a/messaging_daemon/backends/email.py
+++ b/messaging_daemon/backends/email.py
@@ -15,6 +15,7 @@ CLI:
 import argparse
 import email as email_lib
 import imaplib
+import ipaddress
 import json
 import smtplib
 import sqlite3
@@ -160,24 +161,35 @@ class EmailBackend(Backend):
 
     # ── IMAP helpers ──────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _is_loopback_host(host: str) -> bool:
+        host = host.strip().lower().strip("[]")
+        if host == "localhost":
+            return True
+        try:
+            return ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            return False
+
+    @classmethod
+    def _tls_context_for_host(cls, host: str) -> ssl.SSLContext:
+        ctx = ssl.create_default_context()
+        if cls._is_loopback_host(host):
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
     def _imap_connect(self, acct: dict) -> imaplib.IMAP4 | imaplib.IMAP4_SSL:
         host = acct["imap_host"]
         port = int(acct["imap_port"])
         use_ssl = acct.get("imap_ssl", "true").lower() == "true"
+        ctx = self._tls_context_for_host(host)
 
         if use_ssl:
-            if host in ("127.0.0.1", "localhost"):
-                ctx = ssl.create_default_context()
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
-                return imaplib.IMAP4_SSL(host, port, ssl_context=ctx)
-            return imaplib.IMAP4_SSL(host, port)
+            return imaplib.IMAP4_SSL(host, port, ssl_context=ctx)
         else:
             conn = imaplib.IMAP4(host, port)
             if acct.get("imap_starttls", "true").lower() == "true":
-                ctx = ssl.create_default_context()
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
                 conn.starttls(ssl_context=ctx)
             return conn
 
@@ -237,6 +249,7 @@ class EmailBackend(Backend):
         port = int(acct["smtp_port"])
         use_ssl = acct.get("smtp_ssl", "false").lower() == "true"
         use_tls = acct.get("smtp_tls", "true").lower() == "true"
+        ctx = self._tls_context_for_host(host)
 
         msg = MIMEMultipart("alternative")
         msg["From"] = account
@@ -245,17 +258,11 @@ class EmailBackend(Backend):
         msg.attach(MIMEText(body, "plain"))
 
         if use_ssl:
-            if host in ("127.0.0.1", "localhost"):
-                ctx = ssl.create_default_context()
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
-                smtp = smtplib.SMTP_SSL(host, port, context=ctx)
-            else:
-                smtp = smtplib.SMTP_SSL(host, port)
+            smtp = smtplib.SMTP_SSL(host, port, context=ctx)
         else:
             smtp = smtplib.SMTP(host, port)
             if use_tls:
-                smtp.starttls()
+                smtp.starttls(context=ctx)
 
         with smtp:
             smtp.login(account, acct["password"])

--- a/tests/test_email_tls.py
+++ b/tests/test_email_tls.py
@@ -1,0 +1,146 @@
+import ssl
+import unittest
+from unittest.mock import MagicMock, patch
+
+from messaging_daemon.backends.email import EmailBackend
+
+
+class EmailBackendTLSTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = EmailBackend()
+
+    def assert_verified_context(self, ctx: ssl.SSLContext) -> None:
+        self.assertTrue(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def assert_unverified_context(self, ctx: ssl.SSLContext) -> None:
+        self.assertFalse(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+
+    @patch("messaging_daemon.backends.email.imaplib.IMAP4_SSL")
+    def test_imap_ssl_verifies_remote_certificates(self, mock_imap_ssl: MagicMock) -> None:
+        self.backend._imap_connect({
+            "imap_host": "imap.example.com",
+            "imap_port": "993",
+            "imap_ssl": "true",
+        })
+
+        _, kwargs = mock_imap_ssl.call_args
+        self.assert_verified_context(kwargs["ssl_context"])
+
+    @patch("messaging_daemon.backends.email.imaplib.IMAP4_SSL")
+    def test_imap_ssl_skips_verification_for_loopback(self, mock_imap_ssl: MagicMock) -> None:
+        self.backend._imap_connect({
+            "imap_host": "127.0.0.1",
+            "imap_port": "1143",
+            "imap_ssl": "true",
+        })
+
+        _, kwargs = mock_imap_ssl.call_args
+        self.assert_unverified_context(kwargs["ssl_context"])
+
+    @patch("messaging_daemon.backends.email.imaplib.IMAP4")
+    def test_imap_starttls_verifies_remote_certificates(self, mock_imap4: MagicMock) -> None:
+        conn = MagicMock()
+        mock_imap4.return_value = conn
+
+        self.backend._imap_connect({
+            "imap_host": "imap.example.com",
+            "imap_port": "143",
+            "imap_ssl": "false",
+            "imap_starttls": "true",
+        })
+
+        _, kwargs = conn.starttls.call_args
+        self.assert_verified_context(kwargs["ssl_context"])
+
+    @patch("messaging_daemon.backends.email.imaplib.IMAP4")
+    def test_imap_starttls_skips_verification_for_ipv6_loopback(self, mock_imap4: MagicMock) -> None:
+        conn = MagicMock()
+        mock_imap4.return_value = conn
+
+        self.backend._imap_connect({
+            "imap_host": "::1",
+            "imap_port": "143",
+            "imap_ssl": "false",
+            "imap_starttls": "true",
+        })
+
+        _, kwargs = conn.starttls.call_args
+        self.assert_unverified_context(kwargs["ssl_context"])
+
+    @patch("messaging_daemon.backends.email.smtplib.SMTP_SSL")
+    def test_smtp_ssl_verifies_remote_certificates(self, mock_smtp_ssl: MagicMock) -> None:
+        smtp = MagicMock()
+        smtp.__enter__.return_value = smtp
+        mock_smtp_ssl.return_value = smtp
+
+        with patch.object(self.backend, "get_account_config", return_value={
+            "email": "bob@example.com",
+            "password": "secret",
+            "smtp_host": "smtp.example.com",
+            "smtp_port": "465",
+            "smtp_ssl": "true",
+            "smtp_tls": "false",
+        }):
+            self.backend.send("bob@example.com", "alice@example.com", "hello", "subject")
+
+        _, kwargs = mock_smtp_ssl.call_args
+        self.assert_verified_context(kwargs["context"])
+
+    @patch("messaging_daemon.backends.email.smtplib.SMTP_SSL")
+    def test_smtp_ssl_skips_verification_for_loopback(self, mock_smtp_ssl: MagicMock) -> None:
+        smtp = MagicMock()
+        smtp.__enter__.return_value = smtp
+        mock_smtp_ssl.return_value = smtp
+
+        with patch.object(self.backend, "get_account_config", return_value={
+            "email": "bob@example.com",
+            "password": "secret",
+            "smtp_host": "localhost",
+            "smtp_port": "1025",
+            "smtp_ssl": "true",
+            "smtp_tls": "false",
+        }):
+            self.backend.send("bob@example.com", "alice@example.com", "hello", "subject")
+
+        _, kwargs = mock_smtp_ssl.call_args
+        self.assert_unverified_context(kwargs["context"])
+
+    @patch("messaging_daemon.backends.email.smtplib.SMTP")
+    def test_smtp_starttls_verifies_remote_certificates(self, mock_smtp: MagicMock) -> None:
+        smtp = MagicMock()
+        smtp.__enter__.return_value = smtp
+        mock_smtp.return_value = smtp
+
+        with patch.object(self.backend, "get_account_config", return_value={
+            "email": "bob@example.com",
+            "password": "secret",
+            "smtp_host": "smtp.example.com",
+            "smtp_port": "587",
+            "smtp_ssl": "false",
+            "smtp_tls": "true",
+        }):
+            self.backend.send("bob@example.com", "alice@example.com", "hello", "subject")
+
+        _, kwargs = smtp.starttls.call_args
+        self.assert_verified_context(kwargs["context"])
+
+    @patch("messaging_daemon.backends.email.smtplib.SMTP")
+    def test_smtp_starttls_skips_verification_for_loopback(self, mock_smtp: MagicMock) -> None:
+        smtp = MagicMock()
+        smtp.__enter__.return_value = smtp
+        mock_smtp.return_value = smtp
+
+        with patch.object(self.backend, "get_account_config", return_value={
+            "email": "bob@example.com",
+            "password": "secret",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "1025",
+            "smtp_ssl": "false",
+            "smtp_tls": "true",
+        }):
+            self.backend.send("bob@example.com", "alice@example.com", "hello", "subject")
+
+        _, kwargs = smtp.starttls.call_args
+        self.assert_unverified_context(kwargs["context"])


### PR DESCRIPTION
## Summary

This tightens the email backend's TLS trust boundary without changing the localhost / Protonmail Bridge workflow.

## Problem

The code already treats loopback mail transport specially, but for non-local IMAP/SMTP paths it relies on library defaults that do not verify certificates when no explicit TLS context is passed. That means remote IMAPS, SMTPS, and STARTTLS connections can end up running without certificate validation.

For a daemon whose purpose is to safely expose personal messaging to sandboxed AI tools, that weakens the security model in exactly the wrong place.

## What changed

- add a small helper that distinguishes loopback hosts from non-local hosts
- use an explicit TLS context for all IMAP and SMTP SSL / STARTTLS connections
- keep relaxed certificate checks only for loopback hosts (`localhost`, `127.0.0.1`, `::1`)
- add regression tests covering IMAPS, IMAP STARTTLS, SMTPS, and SMTP STARTTLS for both loopback and remote hosts

## Validation

- `python3.11 -m unittest discover -s tests -v`
- `python3.11 -m compileall messaging_daemon tests`
