### PR TITLE
Email backend fixes, Telegram backend, macOS confirmation server fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The recommended usage is to run AI agents and other untrusted software from insi
 - **Signal** via `signal-cli`
 - **Email** via IMAP/SMTP (tested with Protonmail Bridge; works with any standard provider)
 
-## Installation (NixOS)
+## Installation
+
+### NixOS
 
 Add `messaging-daemon.nix` to your imports and rebuild:
 
@@ -20,6 +22,56 @@ imports = [
   ./protonmail-bridge.nix  # if using Protonmail
 ];
 ```
+
+### macOS
+
+This project is mostly portable Python code and can run on macOS without the NixOS module.
+
+Requirements:
+- Python 3.11+
+- `signal-cli` installed and already linked or registered
+- access to your IMAP/SMTP provider (for Gmail, use an app password)
+
+Install the package locally:
+
+```bash
+cd /path/to/messaging-daemon
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Run the daemon in the foreground:
+
+```bash
+messaging-daemon run
+```
+
+Configure Signal:
+
+```bash
+signal-cli link -n "my-mac"
+messaging-daemon signal setup +1XXXXXXXXXX
+```
+
+Configure Gmail:
+
+```bash
+messaging-daemon email add \
+  --email you@gmail.com \
+  --password YOUR_GMAIL_APP_PASSWORD \
+  --imap-host imap.gmail.com --imap-port 993 --imap-ssl true \
+  --smtp-host smtp.gmail.com --smtp-port 587
+```
+
+Check the daemon:
+
+```bash
+curl "http://localhost:6000/accounts"
+curl "http://localhost:6000/status"
+```
+
+Optional: to keep it running in the background on macOS, create a `launchd` agent that starts `python -m messaging_daemon run` or the installed `messaging-daemon run` command.
 
 ## Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,6 +45,8 @@ If either backend shows an empty list, setup is required. **Do not attempt to ru
 ## Setup (instructions to give to the user — do not run these yourself)
 
 > **Agent note:** If setup is needed, copy the relevant instructions below and present them to the user. Remind them that these commands must be run in their own terminal, not inside any sandbox or agent environment. Wait for them to confirm setup is complete before proceeding.
+>
+> **Platform note:** The original service-management examples below assume NixOS/systemd. On macOS, use the same `messaging-daemon ...` account-setup commands, but run the daemon directly (`messaging-daemon run`) or via `launchd` instead of `systemctl`.
 
 ---
 

--- a/messaging_daemon/__main__.py
+++ b/messaging_daemon/__main__.py
@@ -20,10 +20,12 @@ from .db import init_db
 
 from .backends.signal import SignalBackend
 from .backends.email import EmailBackend
+from .backends.telegram import TelegramBackend
 
 BACKENDS: dict = {
-    "signal": SignalBackend(),
-    "email":  EmailBackend(),
+    "signal":   SignalBackend(),
+    "email":    EmailBackend(),
+    "telegram": TelegramBackend(),
 }
 
 # ── Shared imports ────────────────────────────────────────────────────────────

--- a/messaging_daemon/backends/email.py
+++ b/messaging_daemon/backends/email.py
@@ -170,8 +170,9 @@ class EmailBackend(Backend):
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
-                return imaplib.IMAP4_SSL(host, port, ssl_context=ctx)
-            return imaplib.IMAP4_SSL(host, port)
+                conn = imaplib.IMAP4_SSL(host, port, ssl_context=ctx)
+            else:
+                conn = imaplib.IMAP4_SSL(host, port)
         else:
             conn = imaplib.IMAP4(host, port)
             if acct.get("imap_starttls", "true").lower() == "true":
@@ -179,7 +180,9 @@ class EmailBackend(Backend):
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
                 conn.starttls(ssl_context=ctx)
-            return conn
+
+        conn.login(acct["email"], acct["password"])
+        return conn
 
     @staticmethod
     def _decode_header(raw: str | bytes | None) -> str:
@@ -191,10 +194,30 @@ class EmailBackend(Backend):
         decoded = []
         for part, charset in parts:
             if isinstance(part, bytes):
-                decoded.append(part.decode(charset or "utf-8", errors="replace"))
+                for enc in [charset, "utf-8", "latin-1"]:
+                    if not enc:
+                        continue
+                    try:
+                        decoded.append(part.decode(enc, errors="replace"))
+                        break
+                    except (LookupError, TypeError):
+                        continue
+                else:
+                    decoded.append(part.decode("latin-1", errors="replace"))
             else:
                 decoded.append(part)
         return " ".join(decoded)
+
+    @staticmethod
+    def _decode_payload(payload: bytes, charset: str | None) -> str:
+        for enc in [charset, "utf-8", "latin-1"]:
+            if not enc:
+                continue
+            try:
+                return payload.decode(enc, errors="replace")
+            except (LookupError, TypeError):
+                continue
+        return payload.decode("latin-1", errors="replace")
 
     @staticmethod
     def _get_plain_body(msg: email_lib.message.Message) -> str:
@@ -205,15 +228,11 @@ class EmailBackend(Backend):
                         continue
                     payload = part.get_payload(decode=True)
                     if payload:
-                        return payload.decode(
-                            part.get_content_charset() or "utf-8", errors="replace"
-                        )
+                        return EmailBackend._decode_payload(payload, part.get_content_charset())
         else:
             payload = msg.get_payload(decode=True)
             if payload:
-                return payload.decode(
-                    msg.get_content_charset() or "utf-8", errors="replace"
-                )
+                return EmailBackend._decode_payload(payload, msg.get_content_charset())
         return ""
 
     @staticmethod
@@ -269,7 +288,7 @@ class EmailBackend(Backend):
             conn.login(acct["email"], acct["password"])  # Authenticate before selecting folder
             conn.select(f'"{folder}"')
             _, data = conn.uid("search", None, "ALL")
-            uids = data[0].split() if data[0] else []
+            uids = (data[0].split() if data[0] else [])[-100:]
 
             known = {
                 row[0]

--- a/messaging_daemon/backends/telegram.py
+++ b/messaging_daemon/backends/telegram.py
@@ -1,0 +1,199 @@
+"""
+backends/telegram.py — Telegram Bot API backend.
+
+Account config stored in DB:
+  telegram_bot_token   — bot token from BotFather
+  telegram_update_offset — last processed update_id + 1
+
+CLI:
+    messaging-daemon telegram setup --token BOT_TOKEN
+    messaging-daemon telegram list
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from ..db import DB_PATH, get_config, set_config, store_message
+from .base import Backend
+
+API = "https://api.telegram.org/bot{token}/{method}"
+
+_CERTS = os.path.expanduser("~/certs.pem")
+
+
+def _ssl_ctx() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    if os.path.exists(_CERTS):
+        ctx.load_verify_locations(_CERTS)
+    return ctx
+
+
+def _call(token: str, method: str, params: dict | None = None) -> dict:
+    url = API.format(token=token, method=method)
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    with urllib.request.urlopen(url, timeout=30, context=_ssl_ctx()) as resp:
+        return json.loads(resp.read())
+
+
+class TelegramBackend(Backend):
+    name = "telegram"
+
+    # ── Account management ────────────────────────────────────────────────────
+
+    def _get_token(self, db: sqlite3.Connection) -> str | None:
+        return get_config(db, "telegram_bot_token")
+
+    def accounts(self) -> list[dict]:
+        db = sqlite3.connect(DB_PATH)
+        token = self._get_token(db)
+        db.close()
+        if not token:
+            return []
+        try:
+            info = _call(token, "getMe")
+            username = info["result"].get("username", "unknown")
+            return [{"account": f"@{username}", "backend": self.name}]
+        except Exception:
+            return [{"account": "telegram-bot", "backend": self.name}]
+
+    # ── CLI ───────────────────────────────────────────────────────────────────
+
+    def register_commands(self, subparsers: argparse._SubParsersAction) -> None:
+        p = subparsers.add_parser("telegram", help="Telegram backend commands")
+        ts = p.add_subparsers(dest="telegram_command")
+
+        setup = ts.add_parser("setup", help="Set bot token")
+        setup.add_argument("--token", required=True, help="Bot token from BotFather")
+
+        ts.add_parser("list", help="Show configured bot")
+
+    def handle_command(self, args: argparse.Namespace) -> bool:
+        if args.command != "telegram":
+            return False
+        if args.telegram_command == "setup":
+            db = sqlite3.connect(DB_PATH)
+            set_config(db, "telegram_bot_token", args.token)
+            db.close()
+            try:
+                info = _call(args.token, "getMe")
+                username = info["result"].get("username", "?")
+                print(f"Telegram bot saved: @{username}")
+            except Exception as e:
+                print(f"Token saved, but could not verify: {e}")
+        elif args.telegram_command == "list":
+            accts = self.accounts()
+            if not accts:
+                print("No Telegram bot configured.")
+            for a in accts:
+                print(f"  {a['account']}")
+        else:
+            print("Usage: messaging-daemon telegram [setup|list]")
+        return True
+
+    # ── Recipient helpers ─────────────────────────────────────────────────────
+
+    def is_self(self, account: str, recipient: str) -> bool:
+        return recipient.strip().lstrip("@").lower() == account.strip().lstrip("@").lower()
+
+    def resolve_display_name(self, account: str, recipient: str) -> str:
+        return recipient
+
+    # ── Sending ───────────────────────────────────────────────────────────────
+
+    def send(self, account: str, recipient: str, body: str, subject: str | None = None) -> None:
+        db = sqlite3.connect(DB_PATH)
+        token = self._get_token(db)
+        db.close()
+        if not token:
+            raise RuntimeError("No Telegram bot token configured")
+        try:
+            _call(token, "sendMessage", {"chat_id": recipient, "text": body})
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"Telegram sendMessage failed: {e.read().decode()}")
+
+    # ── Polling ───────────────────────────────────────────────────────────────
+
+    def poll(self, db: sqlite3.Connection) -> int:
+        db_conn = sqlite3.connect(DB_PATH)
+        token = self._get_token(db_conn)
+        if not token:
+            print("  [telegram] No bot token configured — skipping poll.")
+            db_conn.close()
+            return 0
+
+        raw_offset = get_config(db_conn, "telegram_update_offset")
+        offset = int(raw_offset) if raw_offset else None
+
+        params: dict = {"limit": 100}
+        if offset is not None:
+            params["offset"] = offset
+
+        try:
+            data = _call(token, "getUpdates", params)
+        except Exception as exc:
+            print(f"  [telegram] getUpdates error: {exc}")
+            db_conn.close()
+            return 0
+
+        updates = data.get("result", [])
+        count = 0
+        new_offset = offset
+
+        for update in updates:
+            update_id = update["update_id"]
+            new_offset = update_id + 1
+
+            msg_data = update.get("message") or update.get("channel_post")
+            if not msg_data:
+                continue
+
+            body = msg_data.get("text")
+            if not body:
+                continue
+
+            chat = msg_data.get("chat", {})
+            from_user = msg_data.get("from", {})
+            chat_id = str(chat.get("id", ""))
+            sender_id = str(from_user.get("id", chat_id))
+            sender_name = (
+                from_user.get("username")
+                or f"{from_user.get('first_name', '')} {from_user.get('last_name', '')}".strip()
+                or chat.get("title")
+                or sender_id
+            )
+
+            msg = {
+                "backend":      self.name,
+                "account":      "telegram",
+                "uid":          str(update_id),
+                "sender":       sender_id,
+                "sender_name":  sender_name,
+                "recipient":    chat_id,
+                "thread_id":    chat_id,
+                "body":         body,
+                "timestamp_ms": msg_data.get("date", 0) * 1000,
+                "metadata":     update,
+            }
+            if store_message(db, msg):
+                count += 1
+
+        if new_offset is not None:
+            set_config(db_conn, "telegram_update_offset", str(new_offset))
+        db_conn.close()
+        return count
+
+    # ── Confirmation page fields ──────────────────────────────────────────────
+
+    def confirmation_fields(self, account, recipient, body, subject):
+        return [
+            ("From", account),
+            ("To", recipient),
+            ("Message", body),
+        ]

--- a/messaging_daemon/confirm.py
+++ b/messaging_daemon/confirm.py
@@ -6,10 +6,25 @@ a random token. Each entry carries enough info to call backend.send() and
 to render a confirmation page via backend.confirmation_fields().
 
 This module is intentionally free of any Signal or email imports.
+
+macOS notes
+-----------
+Port 7000 is used by macOS AirPlay Receiver, which will prevent the server
+from binding. To free it:
+  System Settings → General → AirDrop & Handoff → AirPlay Receiver → Off
+
+Alternatively change CONFIRM_PORT to any unused port (e.g. 7001), but note
+that Chrome blocks several ports (6000, 7000 among others) — use Safari or
+Firefox if you keep ports in that range.
+
+The confirmation URL uses 127.0.0.1 rather than localhost because macOS
+resolves localhost to ::1 (IPv6) while the server binds to IPv4 only,
+causing Safari to get a blank page.
 """
 
 import html as html_lib
 import secrets
+import subprocess
 import threading
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -42,7 +57,9 @@ def enqueue(
             "subject":   subject,
             "created_at": datetime.now(timezone.utc).isoformat(),
         }
-    return f"http://localhost:{CONFIRM_PORT}/confirm?token={token}"
+    url = f"http://127.0.0.1:{CONFIRM_PORT}/confirm?token={token}"
+    subprocess.Popen(["open", "-a", "Safari", url], close_fds=True)
+    return url
 
 
 def pending_count() -> int:


### PR DESCRIPTION
## Summary

- **Email backend**: fix IMAP login (missing `conn.login()` caused NONAUTH errors), add charset fallback chain for non-standard encodings like `unknown-8bit`, limit poll to 100 most recent UIDs to avoid hanging on large inboxes
- **Telegram backend**: new backend using Bot API (stdlib only, no extra deps), with offset-based polling, custom CA bundle support via `~/certs.pem`, and CLI account management
- **macOS confirmation server**: auto-open Safari on pending confirmation (Chrome blocks port 7000); use `127.0.0.1` in URLs instead of `localhost` (macOS resolves localhost to IPv6 ::1 causing blank pages); document AirPlay Receiver port conflict and fix